### PR TITLE
Move Bazel deps to macro

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -13,48 +13,20 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 aspect_bazel_lib_dependencies()
 
-http_archive(
-    name = "rules_python",
-    sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
-    strip_prefix = "rules_python-0.20.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
-)
+load("@//:repositories.bzl", "dbscan_dependencies")
+
+dbscan_dependencies()
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 py_repositories()
 
 python_register_toolchains(
-    name = "python3",
+    name = "dbscan_python",
     python_version = "3.10",
 )
 
-load("@python3//:defs.bzl", "interpreter")
-
-http_archive(
-    name = "pybind11_bazel",
-    # patch_args = ["-p1"],
-    # patches = ["//third_party/pybind11_bazel:python3.10_support.patch"],
-    # sha256 = "fc56ce8a8b51e3dd941139d329b63ccfea1d304b",
-    strip_prefix = "pybind11_bazel-fc56ce8a8b51e3dd941139d329b63ccfea1d304b",
-    urls = ["https://github.com/pybind/pybind11_bazel/archive/fc56ce8a8b51e3dd941139d329b63ccfea1d304b.zip"],
-)
-
-http_archive(
-    name = "pybind11",
-    build_file = "@pybind11_bazel//:pybind11.BUILD",
-    sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970",
-    strip_prefix = "pybind11-2.10.4",
-    urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.10.4.tar.gz"],
-)
-
-load("@pybind11_bazel//:python_configure.bzl", "python_configure")
-
-python_configure(
-    name = "local_config_python",
-    python_interpreter_target = interpreter,
-)
-
+load("@dbscan_python//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
@@ -67,23 +39,3 @@ pip_parse(
 load("@pypi//:requirements.bzl", "install_deps")
 
 install_deps()
-
-http_archive(
-    name = "nanoflann",
-    build_file = "@//third_party:nanoflann.BUILD.bazel",
-    sha256 = "cbcecf22bec528a8673a113ee9b0e134f91f1f96be57e913fa1f74e98e4449fa",
-    strip_prefix = "nanoflann-1.4.3",
-    urls = [
-        "https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.4.3.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "nanobench",
-    build_file = "@//third_party:nanobench.BUILD.bazel",
-    sha256 = "53a5a913fa695c23546661bf2cd22b299e10a3e994d9ed97daf89b5cada0da70",
-    strip_prefix = "nanobench-4.3.11",
-    urls = [
-        "https://github.com/martinus/nanobench/archive/refs/tags/v4.3.11.tar.gz",
-    ],
-)

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 cc_library(
     name = "scoped_timer",
@@ -17,12 +16,14 @@ cc_library(
     ],
 )
 
-pybind_extension(
-    name = "py_dbscan",
+cc_binary(
+    name = "py_dbscan.so",
     srcs = ["py_dbscan.cpp"],
+    linkshared = True,
     visibility = ["//visibility:public"],
     deps = [
         ":dbscan",
+        "@pybind11",
     ],
 )
 

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -11,6 +11,9 @@ compile_pip_requirements(
     ],
     requirements_in = "requirements.in",
     requirements_txt = "requirements_lock.txt",
+    tags = [
+        "manual",
+    ],
 )
 
 py_binary(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,44 @@
+"""Import third_party libraries."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def dbscan_dependencies():
+    maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
+        strip_prefix = "rules_python-0.20.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "nanoflann",
+        build_file = "@dbscan//third_party:nanoflann.BUILD.bazel",
+        sha256 = "cbcecf22bec528a8673a113ee9b0e134f91f1f96be57e913fa1f74e98e4449fa",
+        strip_prefix = "nanoflann-1.4.3",
+        urls = [
+            "https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.4.3.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "nanobench",
+        build_file = "@dbscan//third_party:nanobench.BUILD.bazel",
+        sha256 = "53a5a913fa695c23546661bf2cd22b299e10a3e994d9ed97daf89b5cada0da70",
+        strip_prefix = "nanobench-4.3.11",
+        urls = [
+            "https://github.com/martinus/nanobench/archive/refs/tags/v4.3.11.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "pybind11",
+        build_file = "@dbscan//third_party:pybind11.BUILD.bazel",
+        sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970",
+        strip_prefix = "pybind11-2.10.4",
+        urls = ["https://github.com/pybind/pybind11/archive/refs/tags/v2.10.4.tar.gz"],
+    )

--- a/third_party/pybind11.BUILD.bazel
+++ b/third_party/pybind11.BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "pybind11",
+    hdrs = glob(["include/pybind11/**/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = ["@dbscan_python//:python_headers"],
+)


### PR DESCRIPTION
This moves our dependencies from `WORKSPACE.bazel` to a macro. This way it can easily be called from downstream Bazel workspaces that want to integrate the dbscan workspace.