### PR TITLE
Use pre-commit.ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,21 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - uses: pre-commit/action@v3.0.0
   test:
     name: Run tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Using the pre-commit.ci GH app now, so removing the GH action from the main workflow.