### PR TITLE
Fix case where there is only a single core point

### DIFF
--- a/cpp/dbscan.cpp
+++ b/cpp/dbscan.cpp
@@ -112,7 +112,7 @@ auto Dbscan::fit_predict(std::vector<Dbscan::Point> const& points) -> std::vecto
                 }
                 auto const& neighbor_pt{new_points[neighbor_pt_index]};
                 auto const dist_squared{(square(neighbor_pt[0] - pt[0]) + square(neighbor_pt[1] - pt[1]))};
-                if (dist_squared < eps_squared_) {
+                if (dist_squared <= eps_squared_) {
                     local_neighbors.push_back(neighbor_pt_index);
                 }
             }

--- a/cpp/dbscan.cpp
+++ b/cpp/dbscan.cpp
@@ -111,14 +111,23 @@ auto Dbscan::fit_predict(std::vector<Dbscan::Point> const& points) -> std::vecto
                     continue;
                 }
                 auto const& neighbor_pt{new_points[neighbor_pt_index]};
-                if ((square(neighbor_pt[0] - pt[0]) + square(neighbor_pt[1] - pt[1])) < eps_squared_) {
+                auto const dist_squared{(square(neighbor_pt[0] - pt[0]) + square(neighbor_pt[1] - pt[1]))};
+                if (dist_squared < eps_squared_) {
                     local_neighbors.push_back(neighbor_pt_index);
                 }
             }
         }
 
-        if (std::size(local_neighbors) > min_samples_) {
+        if (std::size(local_neighbors) + 1 >= min_samples_) {
+            // assign first slot of core point entries to itself: this is safe to do without a lock because no other
+            // thread will process the current point i
+            core_points_ids[i][0] = i;
             for (auto const n : local_neighbors) {
+                // TODO: there's the unlikely chance of two threads, working on different points, considering the same
+                // neighbor `n` at the same time, finding that the first slot is empty at the same time, and then both
+                // trying to write their id to that slot, which leads to UB in C++; at least for x86_64 this is probably
+                // fine, since writes of ints are atomic on the hardware level, but it's obviously not clean and should
+                // be done differently.
                 auto& cps{core_points_ids[n]};
                 for (auto cp_id{0U}; cp_id < num_core_points_entries; ++cp_id) {
                     if (cps[cp_id] == -1) {

--- a/python/dbscan_test.py
+++ b/python/dbscan_test.py
@@ -110,5 +110,27 @@ def test_points_on_border2():
     assert np.all(y_pred[10:] == label_b)
 
 
+def test_three_point_cluster_with_single_core_point():
+    """Test the case where we have a single cluster with min_samples points and only the center point is a core point."""
+    X = np.array(
+        [
+            [-1, 0],
+            [0.0, 0],
+            [1, 0],
+            [3, 3],  # noise
+            [2.5, 2.5],  # noise
+        ]
+    )
+
+    eps = 1.01
+    min_samples = 3
+
+    dbscan = py_dbscan.DBSCAN(eps, min_samples)
+
+    y_pred = dbscan.fit_predict(X)
+    assert np.all(y_pred[:3] == 0)
+    assert np.all(y_pred[3:] == -1)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-rP"] + sys.argv[1:]))


### PR DESCRIPTION
The case where a cluster has only a single core point was not handled correctly, as core point IDs were only assigned to found neighbors or a core point, not the core point itself. In most point clouds this was not an issue, because at least two core points were core points for each other, so that they would converge to the same point/label in the merge step. However, when there was only a single core point, this did not work, as there would be no other core point to assign it a core point ID.

Further the condition for checking if min_samples was inconsistent with the sklearn implementation. This is not fixed by including the core point itself in the count and only expecting min_samples to consider a point as a core point, not strictly more than min_samples.